### PR TITLE
[#OEXP-153] Fix Select Component Styling

### DIFF
--- a/src/components/Inputs/Select.js
+++ b/src/components/Inputs/Select.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { withStyles } from "@material-ui/core/styles";
 import MenuItem from "@material-ui/core/MenuItem";
-import TextField from "@material-ui/core/TextField";
+import MuiTextField from "@material-ui/core/TextField";
 import {
   BLUE_50,
   GRAY_50,
@@ -16,54 +16,49 @@ import {
 const styles = theme => {
   return {
     listItem: {
+      padding: "0 8px 0 8px",
+      minHeight: "32px",
       display: "flex",
       alignItems: "center",
-      justifyContent: "flex-start",
-      padding: "3px 5px",
       fontSize: "14px"
     },
+    listPadding: {
+      padding: 0
+    },
     paper: {
-      top: "146px !important",
-      left: "9px !important",
-      boxShadow: `0px 1px 1px ${GRAY_50}`,
+      boxShadow: `0 0 0 1px ${GRAY_50}`,
       borderRadius: 0
     },
-    select: {
-      display: "flex",
-      justifyContent: "flex-start",
-      alignItems: "center",
+    selectSelect: {
+      height: "30px",
+      padding: "0 32px 0 8px",
+      lineHeight: "30px",
+
       "&:focus": {
         background: WHITE
       }
     },
-    listContainer: {
-      padding: 0,
-      width: "320px"
-    },
-    inputLabel: {
-      fontSize: "18px",
-      color: BLACK
-    },
     placeholder: {
       color: GRAY_90
     },
-    inputInput: {
-      padding: "1px 20px 0 0"
-    },
-    inputRoot: {
+    formControlRoot: {
       width: "320px",
+
+      "&$formControlFullWidth": {
+        width: "100%"
+      }
+    },
+    formControlFullWidth: {},
+    inputRoot: {
       backgroundColor: WHITE,
       border: `1px solid ${GRAY_50}`,
       boxSizing: "border-box",
       color: BLACK,
       fontSize: "14px",
       height: "32px",
-      marginTop: "24px",
-      paddingLeft: "8px",
-      paddingRight: "8px",
 
-      "&$inputFormControl": {
-        marginTop: "24px"
+      "$labelRoot + &": {
+        marginTop: "8px"
       },
       "&:hover": {
         border: `1px solid ${GRAY_90}`
@@ -83,13 +78,22 @@ const styles = theme => {
     inputError: {},
     inputFormControl: {},
     inputFocused: {},
-    helperText: {
-      fontStyle: "italic"
+    helperTextRoot: {
+      color: GRAY_90,
+      fontSize: "12px",
+      fontStyle: "italic",
+
+      "&$helperTextError": {
+        color: RED_50
+      }
     },
+    helperTextError: {},
     labelRoot: {
       color: BLACK,
       fontSize: "14px",
-      transform: "scale(1)",
+      transform: "none",
+      transition: "none",
+      position: "static",
 
       "&$labelDisabled": {
         color: BLACK
@@ -116,15 +120,17 @@ function Select({
   onChange,
   disabled,
   error,
+  fullWidth,
   required,
   id,
-  label
+  label,
+  ...rest
 }) {
   let dropdownOptions = options;
   if (placeholder) {
     dropdownOptions = [
       {
-        value: placeholder,
+        value: "",
         menuListContent: (
           <div className={classes.placeholder}>{placeholder}</div>
         )
@@ -133,9 +139,10 @@ function Select({
     ];
   }
   return (
-    <TextField
+    <MuiTextField
       id={id}
       select
+      fullWidth={fullWidth}
       label={label}
       disabled={disabled}
       error={error}
@@ -143,14 +150,18 @@ function Select({
       onChange={onChange}
       FormHelperTextProps={{
         classes: {
-          root: classes.helperText
+          root: classes.helperTextRoot,
+          error: classes.helperTextError
         }
+      }}
+      classes={{
+        root: classes.formControlRoot,
+        fullWidth: classes.formControlFullWidth
       }}
       InputProps={{
         disableUnderline: true,
         classes: {
           root: classes.inputRoot,
-          input: classes.inputInput,
           disabled: classes.inputDisabled,
           error: classes.inputError,
           formControl: classes.inputFormControl,
@@ -159,9 +170,6 @@ function Select({
       }}
       InputLabelProps={{
         shrink: true,
-        classes: {
-          root: classes.inputLabel
-        },
         FormLabelClasses: {
           root: classes.labelRoot,
           disabled: classes.labelDisabled,
@@ -172,18 +180,28 @@ function Select({
       }}
       SelectProps={{
         classes: {
-          select: classes.select
+          select: classes.selectSelect
         },
+        displayEmpty: true,
         MenuProps: {
-          className: classes.menu,
           classes: { paper: classes.paper },
           MenuListProps: {
-            className: classes.listContainer
-          }
+            classes: { padding: classes.listPadding }
+          },
+          anchorOrigin: {
+            vertical: "bottom",
+            horizontal: "left"
+          },
+          transformOrigin: {
+            vertical: "top",
+            horizontal: "left"
+          },
+          getContentAnchorEl: null,
+          marginThreshold: 0
         }
       }}
       helperText={helperText}
-      margin="normal"
+      {...rest}
     >
       {dropdownOptions.map(option => (
         <MenuItem
@@ -195,7 +213,7 @@ function Select({
           {option.menuListContent}
         </MenuItem>
       ))}
-    </TextField>
+    </MuiTextField>
   );
 }
 
@@ -215,6 +233,8 @@ Select.propTypes = {
   disabled: PropTypes.bool,
   /** Adds an asterisk beside label */
   required: PropTypes.bool,
+  /** If true, the input will take up the full width of its container. */
+  fullWidth: PropTypes.bool,
   /** Sets the helper text */
   helperText: PropTypes.node,
   /** These are the options to be displayed in the dropdown.

--- a/src/components/Inputs/Select.stories.js
+++ b/src/components/Inputs/Select.stories.js
@@ -2,15 +2,13 @@ import React from "react";
 import { storiesOf } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 import { withInfo } from "@storybook/addon-info";
-import { createMuiTheme, MuiThemeProvider } from "@material-ui/core/styles";
-import DeleteIcon from "@material-ui/icons/Delete";
-import ThreeSixtyIcon from "@material-ui/icons/ThreeSixty";
+import {
+  createMuiTheme,
+  MuiThemeProvider,
+  withStyles
+} from "@material-ui/core/styles";
 
 import Select, { SelectComponent } from "./Select";
-
-export const actions = {
-  onClick: action("onClick")
-};
 
 const addinTheme = createMuiTheme({
   venaTheme: "addin"
@@ -20,41 +18,46 @@ const webTheme = createMuiTheme({
   venaTheme: "web"
 });
 
+const styles = theme => ({
+  selectField: {
+    margin: "16px 10px 8px 0"
+  },
+  customWidth: {
+    margin: "16px 10px 8px 0",
+    width: "400px"
+  },
+  fullWidthField: {
+    margin: "16px 0 8px 0"
+  }
+});
+
 const dropdownOptions = [
   {
     value: "option1",
-    menuListContent: <div>a</div>
+    menuListContent: "First Option"
   },
   {
     value: "option2",
-    menuListContent: (
-      <>
-        <div style={{ display: "inline-block" }}>
-          <DeleteIcon />
-        </div>
-        <div>Delete this option</div>
-      </>
-    )
+    menuListContent: "Second Option"
   },
   {
     value: "option3",
-    menuListContent: (
-      <>
-        <div style={{ display: "inline-block" }}>
-          <ThreeSixtyIcon />
-        </div>
-        <div
-          style={{
-            display: "inline-block",
-            textOverflow: "ellipsis",
-            overflow: "hidden",
-            paddingLeft: "5px"
-          }}
-        >
-          This is a very long statment that is bigger than the dropdown menu
-        </div>
-      </>
-    )
+    menuListContent: "Third Option"
+  }
+];
+
+const longDropDownOptions = [
+  {
+    value: "option1",
+    menuListContent: "First Option that is longer than the standward width"
+  },
+  {
+    value: "option2",
+    menuListContent: "Second Option that is longer than the standward width"
+  },
+  {
+    value: "option3",
+    menuListContent: "Third Option that is longer than the standward width"
   }
 ];
 
@@ -68,69 +71,124 @@ class SelectDemo extends React.Component {
   };
 
   render() {
+    const { classes } = this.props;
+
     return (
-      <Select
-        id={"dropdown_id"}
-        label={"Select Operation"}
-        helperText={"Some important text"}
-        placeholder={"Select an option"}
-        options={dropdownOptions}
-        value={this.state.value}
-        onChange={this.onChange}
-        required
-      />
+      <>
+        <Select
+          id={"dropdown-base"}
+          label={"Select Operation"}
+          className={classes.selectField}
+          options={dropdownOptions}
+          value={this.state.value}
+          onChange={this.onChange}
+        />
+
+        <Select
+          id={"dropdown-required"}
+          label={"Required"}
+          className={classes.selectField}
+          options={dropdownOptions}
+          value={this.state.value}
+          onChange={this.onChange}
+          required
+        />
+
+        <Select
+          id={"dropdown-helper"}
+          label={"Helper Text"}
+          className={classes.selectField}
+          options={dropdownOptions}
+          value={this.state.value}
+          onChange={this.onChange}
+          helperText={"Some important text"}
+          required
+        />
+
+        <Select
+          id={"dropdown-disabled"}
+          label={"Disabled"}
+          className={classes.selectField}
+          options={dropdownOptions}
+          value={this.state.value}
+          onChange={this.onChange}
+          helperText={"Some important text"}
+          disabled
+        />
+
+        <Select
+          id={"dropdown-placeholder"}
+          label={"With Placeholder"}
+          className={classes.selectField}
+          options={dropdownOptions}
+          value={this.state.value}
+          onChange={this.onChange}
+          helperText={"Some important text"}
+          placeholder="Placeholder"
+        />
+
+        <Select
+          id={"dropdown-error"}
+          label={"Error"}
+          className={classes.selectField}
+          options={dropdownOptions}
+          value={this.state.value}
+          onChange={this.onChange}
+          helperText={"Some important text"}
+          error
+        />
+
+        <Select
+          id={"dropdown-long-options"}
+          label={"Long Options"}
+          className={classes.selectField}
+          options={longDropDownOptions}
+          value={this.state.value}
+          onChange={this.onChange}
+          helperText={"Some important text"}
+        />
+
+        <Select
+          id={"dropdown-custom-width"}
+          label={"Custom Width"}
+          className={classes.customWidth}
+          options={dropdownOptions}
+          value={this.state.value}
+          onChange={this.onChange}
+          helperText={"Some important text"}
+        />
+
+        <Select
+          id={"dropdown-full-width"}
+          label={"Full Width"}
+          className={classes.fullWidthField}
+          options={dropdownOptions}
+          value={this.state.value}
+          onChange={this.onChange}
+          helperText={"Some important text"}
+          fullWidth
+        />
+      </>
     );
   }
 }
 
-storiesOf("Select", module)
-  .add(
-    "Default",
-    withInfo({
-      source: false,
-      propTables: [SelectComponent],
-      propTablesExclude: [Select, SelectDemo, MuiThemeProvider]
-    })(() => (
-      <div>
-        <MuiThemeProvider theme={addinTheme}>
-          <div>
-            <h2>Standard Select</h2>
-            <SelectDemo />
-          </div>
-        </MuiThemeProvider>
-      </div>
-    ))
-  )
-  .add("Disabled", () => (
+const StyledDemo = withStyles(styles)(SelectDemo);
+
+storiesOf("Select", module).add(
+  "Default",
+  withInfo({
+    source: false,
+    propTables: [SelectComponent],
+    propTablesExclude: [Select, SelectDemo, MuiThemeProvider]
+  })(() => (
     <div>
       <MuiThemeProvider theme={addinTheme}>
         <div>
-          <h2>Disabled Select</h2>
-          <Select
-            placeholder={"Select an option"}
-            label={"Select Operation"}
-            options={dropdownOptions}
-            value={""}
-            disabled
-          />
+          <h2>Standard Select</h2>
+          <StyledDemo />
         </div>
       </MuiThemeProvider>
     </div>
   ))
-  .add("Error", () => (
-    <div>
-      <MuiThemeProvider theme={addinTheme}>
-        <div>
-          <h2>Error Select</h2>
-          <Select
-            placeholder={"Select an option"}
-            label={"Select Operation"}
-            options={dropdownOptions}
-            value={""}
-            error
-            helperText={"This is an error"}
-          />
-        </div>
-      </MuiThemeProvider>
-    </div>
-  ));
+);

--- a/src/components/Inputs/Select.stories.js
+++ b/src/components/Inputs/Select.stories.js
@@ -1,12 +1,12 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { action } from "@storybook/addon-actions";
 import { withInfo } from "@storybook/addon-info";
 import {
   createMuiTheme,
   MuiThemeProvider,
   withStyles
 } from "@material-ui/core/styles";
+import DeleteIcon from "@material-ui/icons/Delete";
 
 import Select, { SelectComponent } from "./Select";
 
@@ -58,6 +58,38 @@ const longDropDownOptions = [
   {
     value: "option3",
     menuListContent: "Third Option that is longer than the standward width"
+  }
+];
+
+const jsxOptions = [
+  {
+    value: "option1",
+    menuListContent: (
+      <div style={{ display: "flex", alignItems: "center" }}>
+        <DeleteIcon />
+        First
+      </div>
+    )
+  },
+  {
+    value: "option2",
+    menuListContent: (
+      <div style={{ display: "flex", alignItems: "center" }}>
+        <DeleteIcon />
+        <div style={{ textOverflow: "ellipsis", overflow: "hidden" }}>
+          Second option that is really long and expands past the outside
+        </div>
+      </div>
+    )
+  },
+  {
+    value: "option3",
+    menuListContent: (
+      <div style={{ display: "flex", alignItems: "center" }}>
+        <DeleteIcon />
+        Third
+      </div>
+    )
   }
 ];
 
@@ -167,6 +199,16 @@ class SelectDemo extends React.Component {
           onChange={this.onChange}
           helperText={"Some important text"}
           fullWidth
+        />
+
+        <Select
+          id={"dropdown-full-jsx"}
+          label={"JSX Options"}
+          className={classes.selectField}
+          options={jsxOptions}
+          value={this.state.value}
+          onChange={this.onChange}
+          helperText={"Some important text"}
         />
       </>
     );


### PR DESCRIPTION
### Issue

### Root Cause Analysis
1. The dropdown menu does not align correctly. It only aligned in Storybook because all of the input components were in the same place in every story. If we move the component, the drodown does not follow.
![image](https://user-images.githubusercontent.com/4389490/66512955-0de49400-eaa8-11e9-8298-fdefdfaae34a.png)


### Code change / Fix

1. Refactor the component styling so that the dropdown appears as expected.
2. Remove uses of `!important` in CSS


### Reviewers
@krithika-janaki 
@boweihan 

### Shout Outs :smile_cat:
@boweihan for reporting issues and suggestions on desired behaviour 👍 

