### PR TITLE
[INNO] Updating components colours from GREEN_50 to GREEN_70 for meet a11y color contrast

### DIFF
--- a/src/components/Buttons/Button.js
+++ b/src/components/Buttons/Button.js
@@ -5,8 +5,8 @@ import MuiButton from "@material-ui/core/Button";
 import CircularProgress from "@material-ui/core/CircularProgress";
 import {
   GREEN_30,
-  GREEN_50,
   GREEN_70,
+  GREEN_90,
   BLUE_30,
   BLUE_70,
   BLUE_90,
@@ -88,10 +88,10 @@ const styles = theme => {
       }
     },
     confirmation: {
-      backgroundColor: GREEN_50,
+      backgroundColor: GREEN_70,
 
       "&:hover": {
-        backgroundColor: GREEN_70
+        backgroundColor: GREEN_90
       },
 
       "&:disabled": {

--- a/src/components/Switches/Switch.js
+++ b/src/components/Switches/Switch.js
@@ -3,14 +3,14 @@ import PropTypes from "prop-types";
 import { withStyles } from "@material-ui/core/styles";
 import FormControlLabel from "@material-ui/core/FormControlLabel";
 import MuiSwitch from "@material-ui/core/Switch";
-import { GREEN_50, GRAY_50, GRAY_70, WHITE } from "../../styles/colors";
+import { GREEN_70, GRAY_50, GRAY_70, WHITE } from "../../styles/colors";
 
 const styles = theme => ({
   switchBase: {
     "&$switchChecked": {
       color: WHITE,
       "& + $switchBar": {
-        backgroundColor: GREEN_50
+        backgroundColor: GREEN_70
       }
     },
     transition: theme.transitions.create("transform", {
@@ -40,7 +40,7 @@ const styles = theme => ({
     boxShadow: "none"
   },
   switchLabelOn: {
-    color: GREEN_50,
+    color: GREEN_70,
     fontWeight: 700,
     fontSize: 12,
     marginTop: 1,


### PR DESCRIPTION
**Description**
Design and Product teams have agreed on replacing the old green (GREEN_50) with the new green (GREEN_70) after initial findings via lighthouse audit that revealed there wasn't enough contrast between the primary green (GREEN_50) background color and the white text above it.
The old green (GREEN_50) is going to be used ONLY for the Vena logo when needed.

Updated the background color to a darker one and updated the hover color to a darker one too.

**Note**
Chloe approved these design changes.

Reviewer
@umar-khan